### PR TITLE
feat: viewport オプションに minZoom/maxZoom/zoomEnabled を追加

### DIFF
--- a/packages/@enpitsu/canvas2d/src/enpitsu.ts
+++ b/packages/@enpitsu/canvas2d/src/enpitsu.ts
@@ -17,8 +17,19 @@ const defaultToolPlugins: Map<string, ToolPlugin> = new Map([
 export const useEnpitsu = (
     toolCanvas: HTMLCanvasElement,
     combinedCanvas: HTMLCanvasElement,
-    options?: { tools?: Record<string, ToolPlugin> }
+    options?: {
+        tools?: Record<string, ToolPlugin>
+        viewport?: {
+            minZoom?: number
+            maxZoom?: number
+            zoomEnabled?: boolean
+        }
+    }
 ): Enpitsu => {
+    const minZoom = options?.viewport?.minZoom ?? 0.1
+    const maxZoom = options?.viewport?.maxZoom ?? Infinity
+    const zoomEnabled = options?.viewport?.zoomEnabled ?? true
+
     const dpr = window.devicePixelRatio ?? 1
     const transformer = new ViewportTransformer(1, dpr)
     const store = new StrokeStore()
@@ -104,7 +115,12 @@ export const useEnpitsu = (
             if (isPinching && activePointers.size === 2) {
                 const { dist, mid } = getPinchInfo()
                 const scale = dist / lastPinchDist
-                const newZoom = Math.max(0.1, transformer.zoomRatio * scale)
+                if (!zoomEnabled) {
+                    lastPinchDist = dist
+                    lastPinchMid = mid
+                    return
+                }
+                const newZoom = Math.min(maxZoom, Math.max(minZoom, transformer.zoomRatio * scale))
                 const actualScale = newZoom / transformer.zoomRatio
                 // ピンチ中心でズーム + 中心点の移動でパン
                 transformer.dx = lastPinchMid.x - (lastPinchMid.x - transformer.dx) * actualScale + (mid.x - lastPinchMid.x)
@@ -160,15 +176,17 @@ export const useEnpitsu = (
         ev.preventDefault()
 
         if (ev.ctrlKey) {
-            // ピンチイン・アウト (iOS pinch / Ctrl+scroll)
-            const scale = 1 - ev.deltaY * 0.003
-            const newZoom = Math.max(0.1, transformer.zoomRatio * scale)
-            const actualScale = newZoom / transformer.zoomRatio
+            if (zoomEnabled) {
+                // ピンチイン・アウト (iOS pinch / Ctrl+scroll)
+                const scale = 1 - ev.deltaY * 0.003
+                const newZoom = Math.min(maxZoom, Math.max(minZoom, transformer.zoomRatio * scale))
+                const actualScale = newZoom / transformer.zoomRatio
 
-            // ポインター位置を中心にズーム
-            transformer.dx = ev.offsetX - (ev.offsetX - transformer.dx) * actualScale
-            transformer.dy = ev.offsetY - (ev.offsetY - transformer.dy) * actualScale
-            transformer.zoomRatio = newZoom
+                // ポインター位置を中心にズーム
+                transformer.dx = ev.offsetX - (ev.offsetX - transformer.dx) * actualScale
+                transformer.dy = ev.offsetY - (ev.offsetY - transformer.dy) * actualScale
+                transformer.zoomRatio = newZoom
+            }
         } else {
             // パン (2本指スワイプ)
             transformer.dx -= ev.deltaX


### PR DESCRIPTION
## Summary

- `useEnpitsu` の `options` に `viewport` プロパティを追加
- `minZoom`（デフォルト: 0.1）、`maxZoom`（デフォルト: Infinity）、`zoomEnabled`（デフォルト: true）を設定可能に
- ピンチ操作・ホイール操作の両方でクランプ/無効化が機能する
- オプション未指定時は従来通りの動作を維持

## Test plan

- [ ] `npm run build` が通ること（✅ 確認済み）
- [ ] `npm test` 17件パス（✅ 確認済み）
- [ ] `npm run test:browser` 19件パス（✅ 確認済み）
- [ ] `maxZoom: 3` 設定時にピンチ・ホイールで3倍以上にならないことをブラウザで確認
- [ ] `zoomEnabled: false` 設定時にズーム操作が完全に無効になることを確認

## 使用例

```typescript
// 最小0.5倍、最大5倍に制限
useEnpitsu(toolCanvas, combinedCanvas, {
    viewport: { minZoom: 0.5, maxZoom: 5 }
})

// ズームを完全無効化
useEnpitsu(toolCanvas, combinedCanvas, {
    viewport: { zoomEnabled: false }
})
```

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)