### PR TITLE
fix: GitHub Pages を configure-pages の enablement で自動有効化する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,13 @@ jobs:
         env:
           NUXT_APP_BASE_URL: /enpitsu/
 
+      # enablement: true にすることで、リポジトリ側で GitHub Pages を
+      # 事前に有効化していなくても、main への push 時にワークフローが
+      # Pages(build_type=workflow) を自動で有効化する。
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## 背景 / 調査結果

「GitHub Pages へのデプロイが portfolio のように GitHub Actions 方式になっているか」を確認した結果:

- enpitsu の `deploy.yml` は **既に portfolio と同じ GitHub Actions 方式**（`actions/upload-pages-artifact` + `actions/deploy-pages`）でデプロイする構成になっており、ワークフローの形自体を移植する必要はなかった。
- ただし直近の Deploy 実行（run #29152373194）は **失敗** していた。
- 失敗箇所は `Setup Pages` ステップのみで、`npm run generate` までは成功。原因は **リポジトリ側で GitHub Pages が有効化されていない** こと:

  ```
  ##[error]Get Pages site failed. Please verify that the repository has Pages
  enabled and configured to build using GitHub Actions ...
  ```

  portfolio 側は Pages が有効（`build_type: workflow`）だが、enpitsu は未有効だった。

## 変更内容

`actions/configure-pages@v5` に `enablement: true` を追加。

これにより、リポジトリで事前に Pages を手動有効化しなくても、main への push 時にワークフローが Pages（`build_type=workflow`）を自動有効化してデプロイまで完走する。必要な権限（`pages: write` / `id-token: write`）は既存の workflow で付与済み。

## 検証について

Deploy ジョブは `push: [main]` / `workflow_dispatch` でのみ実行され PR では走らないため、**マージ後**に初めてデプロイが実行される。新規作成された Pages サイトは初回のみ再実行が必要になる場合がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)